### PR TITLE
Fix warning compilation

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,5 +1,8 @@
-CFLAGS +=-Wall -fPIC -I. $(shell erl -noinput -eval 'io:format("-I~s -I~s/erts-~s/include", [code:lib_dir(erl_interface, include), code:root_dir(), erlang:system_info(version)]), halt(0).')
+CFLAGS +=-Wall -Werror -fPIC -I. $(shell erl -noinput -eval 'io:format("-I~s -I~s/erts-~s/include", [code:lib_dir(erl_interface, include), code:root_dir(), erlang:system_info(version)]), halt(0).')
 LDFLAGS +=$(shell erl -noinput -eval 'io:format("-L~s", [code:lib_dir(erl_interface, lib)]), halt(0).')
+ifdef OLD_NIF
+CFLAGS +=-D OLD_NIF
+endif
 
 all: ../priv/lib/gen_socket_nif.so ../priv/lib/gen_socket.so
 

--- a/c_src/gen_socket_drv.c
+++ b/c_src/gen_socket_drv.c
@@ -160,7 +160,11 @@ gs_send_single_atom(GsState* state, ErlDrvTermData atom)
 		ERL_DRV_ATOM, atom,
 		ERL_DRV_TUPLE, 2
 	};
-	driver_output_term(state->drv_port, output, sizeof(output) / sizeof(ErlDrvTermData));
+#ifdef OLD_NIF
+    driver_output_term(state->drv_port, output, sizeof(output) / sizeof(ErlDrvTermData));
+#else
+    erl_drv_output_term(driver_mk_port(state->drv_port), output, sizeof(output) / sizeof(ErlDrvTermData));
+#endif
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,11 @@
             {"(linux|darwin)", "priv/lib/gen_socket_nif.so", ["c_src/gen_socket_nif.c"]},
             {"(linux|darwin)", "priv/lib/gen_socket.so", ["c_src/gen_socket_drv.c"]}]}.
 
+{port_env, [
+            {"R15", "OLD_NIF", "true"}
+           ]
+}.
+
 {pre_hooks,
   [{"(linux|darwin)", compile, "make -C c_src"}]}.
 {post_hooks,


### PR DESCRIPTION
I use new nif erl_drv_output_term instead deprecated driver_output_term