### PR TITLE
Fix compilation on Alpine:3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: erlang
 otp_release:
-    - R15B03
     - R16B
     - R16B03-1
     - 17.4

--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ Using rebar:
 [travis badge]: https://img.shields.io/travis/travelping/gen_socket/master.svg?style=flat-square
 [coveralls]: https://coveralls.io/github/travelping/gen_socket
 [coveralls badge]: https://img.shields.io/coveralls/travelping/gen_socket/master.svg?style=flat-square
-[erlang version badge]: https://img.shields.io/badge/erlang-R15B03%20to%2020.1-blue.svg?style=flat-square
+[erlang version badge]: https://img.shields.io/badge/erlang-r16%20to%2020.1-blue.svg?style=flat-square
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,8 +1,5 @@
 CFLAGS +=-Wall -Werror -fPIC -I. $(shell erl -noinput -eval 'io:format("-I~s -I~s/erts-~s/include", [code:lib_dir(erl_interface, include), code:root_dir(), erlang:system_info(version)]), halt(0).')
 LDFLAGS +=$(shell erl -noinput -eval 'io:format("-L~s", [code:lib_dir(erl_interface, lib)]), halt(0).')
-ifdef OLD_NIF
-CFLAGS +=-D OLD_NIF
-endif
 
 all: ../priv/lib/gen_socket_nif.so ../priv/lib/gen_socket.so
 

--- a/c_src/gen_socket_drv.c
+++ b/c_src/gen_socket_drv.c
@@ -38,7 +38,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <error.h>
 
 // addresses
 #include <sys/un.h>

--- a/c_src/gen_socket_drv.c
+++ b/c_src/gen_socket_drv.c
@@ -159,11 +159,7 @@ gs_send_single_atom(GsState* state, ErlDrvTermData atom)
 		ERL_DRV_ATOM, atom,
 		ERL_DRV_TUPLE, 2
 	};
-#ifdef OLD_NIF
-    driver_output_term(state->drv_port, output, sizeof(output) / sizeof(ErlDrvTermData));
-#else
-    erl_drv_output_term(driver_mk_port(state->drv_port), output, sizeof(output) / sizeof(ErlDrvTermData));
-#endif
+	erl_drv_output_term(driver_mk_port(state->drv_port), output, sizeof(output) / sizeof(ErlDrvTermData));
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/c_src/gen_socket_nif.c
+++ b/c_src/gen_socket_nif.c
@@ -45,6 +45,7 @@
 #include <limits.h>
 #include <fcntl.h>
 #include <err.h>
+#include <errno.h>
 #include <sched.h>
 
 #include <unistd.h>
@@ -55,8 +56,6 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <net/if.h>
-
-#include <sys/errno.h>
 
 #include <sys/ioctl.h>
 

--- a/rebar.config
+++ b/rebar.config
@@ -2,11 +2,6 @@
             {"(linux|darwin)", "priv/lib/gen_socket_nif.so", ["c_src/gen_socket_nif.c"]},
             {"(linux|darwin)", "priv/lib/gen_socket.so", ["c_src/gen_socket_drv.c"]}]}.
 
-{port_env, [
-            {"R15", "OLD_NIF", "true"}
-           ]
-}.
-
 {pre_hooks,
   [{"(linux|darwin)", compile, "make -C c_src"}]}.
 {post_hooks,


### PR DESCRIPTION
The fix for c_src/gen_socket_nif.c includes 'errno.h' (insteadof 'sys/errno.h')
which is part of the standard C library.

```
cc -Wall -Werror -fPIC -I. -I/usr/lib/erlang/lib/erl_interface-3.10/include
  -I/usr/lib/erlang/erts-9.1.5/include
  -c -o gen_socket_nif.o gen_socket_nif.c
In file included from gen_socket_nif.c:59:0:
/usr/include/sys/errno.h:1:2: error: #warning redirecting incorrect
 #include <sys/errno.h> to <errno.h> [-Werror=cpp]

 #warning redirecting incorrect #include <sys/errno.h> to <errno.h>
  ^~~~~~~
cc1: all warnings being treated as errors
```

The fix for c_src/gen_socket_drv.c just removes the apparently unused
'error.h' header which was not available anyway on Alpine Linux:

```
cc -Wall -Werror -fPIC -I. -I/usr/lib/erlang/lib/erl_interface-3.10/include
  -I/usr/lib/erlang/erts-9.1.5/include
  -c -o gen_socket_drv.o gen_socket_drv.c
gen_socket_drv.c:41:19: fatal error: error.h: No such file or directory
 #include <error.h>
```