### PR TITLE
Makefile: Fix compilation from OTP-23 onwards

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -9,8 +9,10 @@ clean:
 
 ../priv/lib/gen_socket_nif.so: gen_socket_nif.o
 	(test -d ../priv/lib || mkdir -p ../priv/lib)
-	$(CC) $(CFLAGS) $(LDFLAGS) gen_socket_nif.o -o ../priv/lib/gen_socket_nif.so -shared -lei -lerl_interface
+	$(CC) $(CFLAGS) $(LDFLAGS) gen_socket_nif.o -o ../priv/lib/gen_socket_nif.so -shared -lei
+#-lerl_interface
 
 ../priv/lib/gen_socket.so: gen_socket_drv.o
 	(test -d ../priv/lib || mkdir -p ../priv/lib)
-	$(CC) $(CFLAGS) $(LDFLAGS) gen_socket_drv.o -o ../priv/lib/gen_socket.so -shared -lei -lerl_interface
+	$(CC) $(CFLAGS) $(LDFLAGS) gen_socket_drv.o -o ../priv/lib/gen_socket.so -shared -lei
+#-lerl_interface


### PR DESCRIPTION
It has been tested against OTP-24 and OTP-26, and in both cases it fixes the compilation error.

* https://www.erlang.org/news/140: "erl_interface: Removed the deprecated parts of erl_interface (erl_interface.h and essentially all C functions with prefix erl_)."

* https://elixirforum.com/t/where-is-liberl-interface-a-in-otp-23/35406